### PR TITLE
Standard notation and others

### DIFF
--- a/docs/algebra/groups/definition.md
+++ b/docs/algebra/groups/definition.md
@@ -1,15 +1,15 @@
 # Definition
 
-A _group_ \((G, *)\) consists of a set \(G\) and a binary operation \(*\) such that
+A _group_ \((G, * )\) consists of a set \(G\) and a binary operation \(*\) such that
 
 - \(G\) is closed under \(*\)  
-This means that if \(g*h\) belongs to \(G\) for all \(g, h \in G\).
+This means that if \(g * h\) belongs to \(G\) for all \(g, h \in G\).
 - Associativity  
 This implies that \(g_1 * (g_2 * g_3) = (g_1 * g_2) * g_3\) for all \(g_1, g_2, g_3 \in G\).
 - There exists an identity element  
-There exists an element \(1\) such that \(g * 1 = 1 * g = g\) for all \(g \in G\).
+There exists an element \(e\) such that \(g * e = e * g = g\) for all \(g \in G\).
 - Every element has an inverse.  
-For every element \(g \in G\), there exists an element \(h\) such that \(gh = hg = 1\).
+For every element \(g \in G\), there exists an element \(h\) such that \(g * h = h * g = e\).
 
 Some examples of groups are \((\mathbb{Z}, +)\), \((\mathbb{Z}_0, \times)\).
 
@@ -17,7 +17,7 @@ If the group operation is commutative, then we say the group is _abelian_.
 
 The _order of the group_ is the number of elements in the group. \(|G|\).
 
-The _order of an element_ \(g\) is the minimum integer \(n\) such that \(g^n = 1\). 
+The _order of an element_ \(g\) is the minimum integer \(n\) such that \(g^n = e\). 
 
 
 <!-- --8<-- "includes/glossary.md" -->


### PR DESCRIPTION
Usually the "identity element" (or "neutral element") is indicated by "e".
If your operator ( * ) is like a usual "multiplicative operator" (over real numbers: 2 * 3 = 6) or if there is no ambiguity, you can omit the operator. 
The same goes for the "identity element", if your operator ( * ) is like a usual {"multiplicative operator" or "additive operator"} you can indicate with {1 or 0} respectively.
if you are working with more than one group the usual notation is: *_G; e_G.